### PR TITLE
Add support for reviews creation in the API

### DIFF
--- a/app/controllers/api/v1/reviews_controller.rb
+++ b/app/controllers/api/v1/reviews_controller.rb
@@ -1,0 +1,18 @@
+class Api::V1::ReviewsController < ApplicationController
+  before_filter :authenticate, only: [:create]
+
+  def create
+    review = Review.new review_params
+    review.user_id = current_user.id
+
+    if review.save
+      render json: review
+    else
+      render json: review.errors
+    end
+  end
+
+  def review_params
+    params.require(:review).permit(:place_id)
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,18 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+
+  def authenticate
+    authenticate_or_request_with_http_token do |token, options|
+      User.where(api_token: token).any?
+    end
+  end
+
+  def current_user
+    User.where(api_token: current_api_token).first
+  end
+
+  def current_api_token
+    /(.*)=\"(.*)\"/.match(request.headers["Authorization"])[2]
+  end
 end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -1,0 +1,3 @@
+class Review < ActiveRecord::Base
+  validates :place_id, :user_id, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,8 @@
+class User < ActiveRecord::Base
+  validates :first_name, :last_name, :email, :api_token, presence: true
+  validates :email, :api_token, uniqueness: true
+
+  before_validation do
+    self.api_token = SecureRandom.hex
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
+      resources :reviews, only: :create
       resources :places, only: :none do
         collection do
           get(

--- a/db/migrate/20141203220953_create_reviews.rb
+++ b/db/migrate/20141203220953_create_reviews.rb
@@ -1,0 +1,9 @@
+class CreateReviews < ActiveRecord::Migration
+  def change
+    create_table :reviews do |t|
+      t.integer :place_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20141204014609_add_user_id_to_review.rb
+++ b/db/migrate/20141204014609_add_user_id_to_review.rb
@@ -1,0 +1,5 @@
+class AddUserIdToReview < ActiveRecord::Migration
+  def change
+    add_column :reviews, :user_id, :integer
+  end
+end

--- a/db/migrate/20141204015402_create_users.rb
+++ b/db/migrate/20141204015402_create_users.rb
@@ -1,0 +1,12 @@
+class CreateUsers < ActiveRecord::Migration
+  def change
+    create_table :users do |t|
+      t.string :first_name
+      t.string :last_name
+      t.string :email
+      t.string :api_token
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,17 +11,39 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141114195924) do
+ActiveRecord::Schema.define(version: 20141204015402) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "cube"
   enable_extension "earthdistance"
 
+  create_table "api_keys", force: true do |t|
+    t.string   "access_token"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
   create_table "places", force: true do |t|
     t.float    "lat"
     t.float    "lng"
     t.string   "name"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  create_table "reviews", force: true do |t|
+    t.integer  "place_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer  "user_id"
+  end
+
+  create_table "users", force: true do |t|
+    t.string   "first_name"
+    t.string   "last_name"
+    t.string   "email"
+    t.string   "api_token"
     t.datetime "created_at"
     t.datetime "updated_at"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,12 +18,6 @@ ActiveRecord::Schema.define(version: 20141204015402) do
   enable_extension "cube"
   enable_extension "earthdistance"
 
-  create_table "api_keys", force: true do |t|
-    t.string   "access_token"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
   create_table "places", force: true do |t|
     t.float    "lat"
     t.float    "lng"

--- a/spec/controllers/api/v1/reviews_controller_spec.rb
+++ b/spec/controllers/api/v1/reviews_controller_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::ReviewsController, :type => :controller do
+  describe "POST create" do
+    let(:place) { Place.make! }
+    let(:user) { User.make! }
+
+    context "when it's a valid API token" do
+      before { request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Token.encode_credentials(user.api_token) }
+
+      context "when it's a valid review" do
+        it "should create a new review" do
+          expect {
+            post :create, review: { place_id: place.id }, format: :json
+          }.to change { Review.count }.by(1)
+        end
+
+        it "should return the new review" do
+          post :create, review: { place_id: place.id }, format: :json
+          review = JSON.parse(response.body)
+          expect(review["place_id"]).to be_eql(place.id)
+        end
+      end
+
+      context "when it's an invalid review" do
+        it "should not create a new review" do
+          expect {
+            post :create, review: { place_id: nil }, format: :json
+          }.to change { Review.count }.by(0)
+        end
+
+        it "should return the review errors" do
+          post :create, review: { place_id: nil }, format: :json
+          review = JSON.parse(response.body)
+          expect(review["place_id"]).to be_eql(["can't be blank"])
+        end
+      end
+    end
+
+    context "when it's an invalid token" do
+      it "should return unauthorized" do
+        post :create, review: { place_id: 1 }, format: :json
+        expect(response.status).to be_eql(401)
+      end
+    end
+  end
+end

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe Review, :type => :model do
+  it { should validate_presence_of :place_id }
+  it { should validate_presence_of :user_id }
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe User, :type => :model do
+  it { should validate_presence_of :first_name }
+  it { should validate_presence_of :last_name }
+  it { should validate_presence_of :email }
+  it { should validate_uniqueness_of :email }
+
+  it "should genereate an API token" do
+    user = User.create first_name: "Mario", last_name: "Gotze", email: "gotze@trashmail.com"
+    expect(user.api_token).to_not be_nil
+  end
+end

--- a/spec/support/blueprints.rb
+++ b/spec/support/blueprints.rb
@@ -5,3 +5,13 @@ Place.blueprint do
   lat { -23.0039539 }
   lng { -43.3067975 }
 end
+
+Review.blueprint do
+  # Attributes here
+end
+
+User.blueprint do
+  first_name { "Lionel" }
+  last_name { "Messi" }
+  email { "lionel#{sn}@trashmail.com" }
+end


### PR DESCRIPTION
I kept the reviews table as simple as possible, I believe we can gradually improve this table with more columns while we decide how it should work.

In this pull request I added an authentication routine to protect the API methods, as long as the users table.
