### PR TITLE
Add API method for user creation

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,15 @@
+class Api::V1::UsersController < ApplicationController
+  def create
+    user = User.new user_params
+
+    if user.save
+      render json: user
+    else
+      render json: user.errors
+    end
+  end
+
+  def user_params
+    params.require(:user).permit(:first_name, :last_name, :email)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :reviews, only: :create
+      resources :users, only: :create
       resources :places, only: :show do
         collection do
           get(

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::UsersController, :type => :controller do
+  describe "POST create" do
+    context "when it's a valid user" do
+      let(:user_params) do
+        {
+          first_name: "Roberto",
+          last_name: "Bolaños",
+          email: "bolanos@trashmail.com"
+        }
+      end
+
+      it "should create a new user" do
+        expect {
+          post :create, user: user_params, format: :json
+        }.to change { User.count }.by(1)
+      end
+
+      it "should return the new user" do
+        post :create, user: user_params, format: :json
+        user = JSON.parse(response.body)
+        expect(user["email"]).to be_eql(user_params[:email])
+      end
+    end
+
+    context "when it's an invalid user" do
+      let(:user_params) do
+        { email: "bolanos@trashmail.com" }
+      end
+
+      it "should not create a new user" do
+        expect {
+          post :create, user: user_params, format: :json
+        }.to change { User.count }.by(0)
+      end
+
+      it "should return the user errors" do
+        post :create, user: user_params, format: :json
+        user = JSON.parse(response.body)
+        expect(user["first_name"]).to be_eql(["can't be blank"])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Once again, I took the simpler way to enable the mobile apps to create new users. It's only three attributes, first_name, last_name and email, but the implementation is flexible enough to extend the API for more attributes as soon as they are needed.
